### PR TITLE
refactor: streamline rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.45"
+serde = { version = "*", features = ["derive"] }
+serde_json = "*"
 near-sdk = "0.9.2"
-borsh = "0.6.0"
+borsh = "*"
 wee_alloc = { version = "0.4.5", default-features = false, features = [] }
 
 [profile.release]


### PR DESCRIPTION
Partially satisfies https://github.com/near/devx/issues/157

Following the advice given [here] to ensure there are no different versions of common libraries

  [here]: https://github.com/near-examples/rust-status-message/pull/13#discussion_r416946300